### PR TITLE
fix: allow updating fees even if it is set

### DIFF
--- a/chain/rust/src/builders/tx_builder.rs
+++ b/chain/rust/src/builders/tx_builder.rs
@@ -1557,7 +1557,7 @@ pub fn add_change_if_needed(
     let fee = match &builder.fee {
         None => builder.min_fee(include_exunits),
         // generating the change output involves changing the fee
-        Some(_x) => return Ok(false),
+        Some(set_fee) => Ok(set_fee.clone()),
     }?;
 
     // note: can't add datum / script_ref to change

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cardano-multiplatform-lib",
-  "version": "5.1.0",
+  "version": "5.3.1-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cardano-multiplatform-lib",
-      "version": "5.1.0",
+      "version": "5.3.1-2",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
This is necessary to allow setting custom fees via LucidEvolution and still benefit from change output calculation by CML. Currently, if you set fees using `TransactionBuilder::set_fee`, change output is not added by CML. 
Having this change helps with adding the newly introduced reference fees with minimal change to CML or [LucidEvo](https://github.com/Anastasia-Labs/lucid-evolution/commit/8d1a1d29e419d3e67ce63ca65ee8467c57d25737#diff-1676588fadf831081beb5532c22aba053c82f7b0eb4d3f1da7ed9d33cd51b343R426)